### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This Google Cast demo app shows how to cast videos from a Chrome browser using C
  2. Use the default media receiver app: no change or change YOUR_APP_ID to your own in helloVideos.js
  4. Open a browser and point to your page at http://[YOUR_SERVER_LOCATION]/helloVideos/index.html
 
-##Documentation
+## Documentation
 * Cast APIs: http://developers.google.com/cast/docs/chrome_sender
 
 ## References and How to report bugs


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
