### PR TITLE
Fix initialization.

### DIFF
--- a/helloVideos.js
+++ b/helloVideos.js
@@ -60,9 +60,11 @@ var timer = null;
 /**
  * Call initialization
  */
-if (!chrome.cast || !chrome.cast.isAvailable) {
-  setTimeout(initializeCastApi, CAST_API_INITIALIZATION_DELAY);
-}
+window['__onGCastApiAvailable'] = function(isAvailable) {
+  if (isAvailable) {
+    initializeCastApi();
+  }
+};
 
 /**
  * initialization

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <title>Google Cast Chrome Sender SDK: Hello Videos</title>
 <link rel="stylesheet" type="text/css" href="css/demo.css">
-<script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender_test.js"></script>
+<script type="text/javascript" src="https://www.gstatic.com/cv/js/sender/v1/cast_sender.js"></script>
 <script src="helloVideos.js"></script>
 </head>
 <body>


### PR DESCRIPTION
Use the correct initialization pattern for the Cast SDK.
This also allows index.html to load in non-Chrome browsers.
